### PR TITLE
ci(github-actions): fix heredoc syntax in AI code review workflow

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -40,7 +40,7 @@ jobs:
           PR_DIFF=$(echo "$ENCODED_DIFF" | base64 --decode)
 
           # Create prompt with proper heredoc syntax
-          cat << 'EOF' > prompt.txt
+          cat << EOF > prompt.txt
           You are a senior software engineer with deep expertise in code refactoring and software design patterns. Your mission is to enhance code structure, readability, and maintainability while preserving its exact functionality. Follow these steps for effective code analysis and refactoring:
 
           1. **Initial Assessment**: Fully understand the code's current functionality. If clarification is needed regarding the code's purpose or constraints, ask specific questions such as:


### PR DESCRIPTION
The heredoc syntax was incorrectly using single quotes which could cause variable expansion issues. Remove the quotes to ensure proper variable interpolation in the generated prompt. With this simple change, the Gemini API will receive the actual code changes and will be able to provide a relevant, accurate review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow script configuration for improved processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->